### PR TITLE
降级开发框架依赖typing_extensions版本

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ gevent==1.2.2
 python-consul==1.1.0
 PyYAML==5.3
 dataclasses==0.7
+typing_extensions==3.7.4.3
 
 # for原生es
 elasticsearch==7.0.0


### PR DESCRIPTION
sprintfix: 降级开发框架依赖typing_extensions版本