### PR TITLE
minor: 第三方es中time_field获取失败

### DIFF
--- a/apps/log_esquery/serializers.py
+++ b/apps/log_esquery/serializers.py
@@ -369,10 +369,13 @@ def _init_index_info(*, index_set_id):
             index = [x.get("result_table_id", None) for x in index_set_data_obj_list]
             indices = ",".join(index)
             if scenario_id not in [Scenario.BKDATA, Scenario.LOG]:
-                time_field_list = [x.get("time_field", None) for x in index_set_data_obj_list]
-                if len(time_field_list) > 0:
-                    time_field = time_field_list[0]
-                else:
+                time_field = None
+                for x in index_set_data_obj_list:
+                    time_field = x.get("time_field")
+                    if time_field:
+                        break
+                time_field = time_field or tmp_index_obj.time_field
+                if time_field is None:
                     raise BaseSearchIndexSetIdTimeFieldException(
                         BaseSearchIndexSetIdTimeFieldException.MESSAGE.format(index_set_id=index_set_id)
                     )


### PR DESCRIPTION
minor: 第三方es，通过index_set_id获取time_field，首先从子index中获取，子index没有的情况下，再从index_set本身获取，最后再报错